### PR TITLE
Update CaFeZn attribution text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > 算法来源于 <a href="https://bbs.robomaster.com/article/557395" target="_blank" title="RoboMaster 论坛相关文章">RoboMaster 论坛</a>。
 
 贡献者（时间顺序）：
-- [西南石油大学-铁人](https://github.com/CaFeZn)
+- [CaFeZn](https://github.com/CaFeZn)
 - [LC](https://github.com/lc6464)
 - [MeroT](https://github.com/tearncolour)
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <section class="info-section">
             <h2>工具说明</h2>
             <div class="info-content">
-                <p>此存储库由<a href="https://github.com/CaFeZn">西南石油大学-铁人</a>、<a href="https://github.com/lc6464">LC</a>
+                <p>此存储库由<a href="https://github.com/CaFeZn">CaFeZn</a>、<a href="https://github.com/lc6464">LC</a>
                     和 <a href="https://github.com/tearncolour">MeroT</a> 共同贡献。<br />
                     欢迎为
                     <a href="https://github.com/lc6464/CANbus-Load-Calculator" target="_blank">此存储库</a>


### PR DESCRIPTION
## Summary
- replace the README contributor label with CaFeZn
- replace the webpage contributor label with CaFeZn

## Testing
- not run (text-only change)